### PR TITLE
Updated example/config.yml with default "hourly" parameter.

### DIFF
--- a/virt_backup/backups/pending.py
+++ b/virt_backup/backups/pending.py
@@ -230,7 +230,7 @@ class DomBackup(_BaseDomBackup):
         if self.compression not in (None, "tar"):
             mode = "w:{}".format(self.compression)
             extension = "tar.{}".format(self.compression)
-            if self.compression is "xz":
+            if self.compression == "xz":
                 extra_args["preset"] = self.compression_lvl
             else:
                 extra_args["compresslevel"] = self.compression_lvl


### PR DESCRIPTION
Leaving the "hourly" parameter unspecified in a group will lead to all backups being kept on every "clean" pass, regardless of their daily/weekly/monthly/yearly parameters. It took me a while to figure out that the problem was that the group I had created did not specify "hourly". If "hourly" is specified in defaults as "1", at least when not specifying it in individual groups it won't affect the cleanup of backups.