### PR TITLE
Match domains by UUID

### DIFF
--- a/virt_backup/backups/pending.py
+++ b/virt_backup/backups/pending.py
@@ -409,7 +409,7 @@ class DomBackup(_BaseDomBackup):
         packager and packager_opts, self and dombackup are considered
         compatibles.
         """
-        same_domain = dombackup.dom.ID() == self.dom.ID()
+        same_domain = dombackup.dom.UUID() == self.dom.UUID()
         if not same_domain:
             return False
 

--- a/virt_backup/backups/snapshot.py
+++ b/virt_backup/backups/snapshot.py
@@ -290,7 +290,7 @@ class DomExtSnapshot:
         If the received domain matches with the one associated to this backup,
         abort the blockjob, pivot it and delete the snapshot.
         """
-        domain_matches = dom.ID() == self.dom.ID()
+        domain_matches = dom.UUID() == self.dom.UUID()
         if status == libvirt.VIR_DOMAIN_BLOCK_JOB_READY and domain_matches:
             dom.blockJobAbort(snap, libvirt.VIR_DOMAIN_BLOCK_JOB_ABORT_PIVOT)
             os.remove(snap)

--- a/virt_backup/groups/pending.py
+++ b/virt_backup/groups/pending.py
@@ -169,7 +169,7 @@ class BackupGroup:
         :returns: a generator of DomBackup matching
         """
         for backup in self.backups:
-            if backup.dom.ID() == dom.ID():
+            if backup.dom.UUID() == dom.UUID():
                 yield backup
 
     def propagate_default_backup_attr(self):


### PR DESCRIPTION
For all non-active domains .ID() returns the same -1.

<!--
    Thank you for your interest in contributing to virt-backup!

    Please note that this project uses black: https://black.readthedocs.io/en/stable/
    Install black via: https://black.readthedocs.io/en/stable/installation_and_usage.html#installation
    Then run from the root of this repository: black virt_backup tests

    WARNING: CI checks for black are enabled, Travis will then fail if there is any format issue.
-->
