### PR TITLE
Remove argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     keywords="libvirt",
     packages=find_packages(exclude=["example", "tests"]),
     install_requires=[
-        "appdirs", "argparse", "arrow", "libvirt-python", "lxml", "packaging", "PyYAML"
+        "appdirs", "arrow", "libvirt-python", "lxml", "packaging", "PyYAML"
     ],
     setup_requires=['pytest-runner', ],
     # Deepdiff: 5.0.2 forced for Python 3.5 compatibility.


### PR DESCRIPTION
`argparse` is a [standard lib](https://docs.python.org/3/library/argparse.html).

<!--
    Thank you for your interest in contributing to virt-backup!

    Please note that this project uses black: https://black.readthedocs.io/en/stable/
    Install black via: https://black.readthedocs.io/en/stable/installation_and_usage.html#installation
    Then run from the root of this repository: black virt_backup tests

    WARNING: CI checks for black are enabled, Travis will then fail if there is any format issue.
-->
