### PR TITLE
packagers raise a FileExistsError upon restore

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -108,7 +108,7 @@ $ virt-backup list -h
 usage: virt-backup list [-h] [-D domain_name] [-s] [group [group ...]]
 
 positional arguments:
-  group                 domain group to clean
+  group                 domain group to list
 
 optional arguments:
   -D domain_name, --domain domain_name
@@ -133,7 +133,7 @@ usage: virt-backup restore [-h] [--date date] group domain target_dir
 positional arguments:
   group        domain group
   domain       domain name
-  target_dir   backup date
+  target_dir   destination path
 
 optional arguments:
   --date date  backup date (default: last backup)

--- a/virt_backup/__main__.py
+++ b/virt_backup/__main__.py
@@ -47,7 +47,7 @@ def build_parser():
     sp_restore.add_argument(
         "--date", metavar="date", help="backup date (default: last backup)"
     )
-    sp_restore.add_argument("target_dir", metavar="target_dir", help="backup date")
+    sp_restore.add_argument("target_dir", metavar="target_dir", help="destination path")
     sp_restore.set_defaults(func=restore_backup)
 
     sp_clean = sp_action.add_parser("clean", aliases=["cl"], help=("clean groups"))

--- a/virt_backup/backups/packagers/tar.py
+++ b/virt_backup/backups/packagers/tar.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import tarfile
 
-from virt_backup.exceptions import CancelledError, ImageNotFoundError
+from virt_backup.exceptions import CancelledError, ImageNotFoundError, ImageFoundError
 from . import (
     _AbstractBackupPackager,
     _AbstractReadBackupPackager,
@@ -104,6 +104,8 @@ class ReadBackupPackagerTar(_AbstractReadBackupPackager, _AbstractBackupPackager
             os.makedirs(target)
         if os.path.isdir(target):
             target = os.path.join(target, name)
+        if os.path.isfile(target):
+            raise ImageFoundError(target)
 
         buffersize = 2 ** 20
         self._tarfile.fileobj.flush()

--- a/virt_backup/backups/packagers/zstd.py
+++ b/virt_backup/backups/packagers/zstd.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import zstandard as zstd
 
-from virt_backup.exceptions import CancelledError, ImageNotFoundError
+from virt_backup.exceptions import CancelledError, ImageNotFoundError, ImageFoundError
 from . import (
     _AbstractBackupPackager,
     _AbstractReadBackupPackager,
@@ -82,6 +82,8 @@ class ReadBackupPackagerZSTD(_AbstractReadBackupPackager, _AbstractBackupPackage
             os.makedirs(target)
         if os.path.isdir(target):
             target = os.path.join(target, name)
+        if os.path.isfile(target):
+            raise ImageFoundError(target)
 
         buffersize = 2 ** 20
         dctx = zstd.ZstdDecompressor()

--- a/virt_backup/exceptions.py
+++ b/virt_backup/exceptions.py
@@ -43,6 +43,11 @@ class ImageNotFoundError(Exception):
         super().__init__("Image {} not found in {}".format(image, target))
 
 
+class ImageFoundError(Exception):
+    def __init__(self, image):
+        super().__init__("Image {} found".format(image))
+
+
 class DomainRunningError(Exception):
     """
     Domain is running when a task would need it to be shutdown


### PR DESCRIPTION
When the try/except block around line 89 catches the exception the file is removed but no restore is actually performed.

Correct README and parser help text.

<!--
    Thank you for your interest in contributing to virt-backup!

    Please note that this project uses black: https://black.readthedocs.io/en/stable/
    Install black via: https://black.readthedocs.io/en/stable/installation_and_usage.html#installation
    Then run from the root of this repository: black virt_backup tests

    WARNING: CI checks for black are enabled, Travis will then fail if there is any format issue.
-->
