### PR TITLE
guard against simultaneous clean runs

### DIFF
--- a/virt_backup/groups/complete.py
+++ b/virt_backup/groups/complete.py
@@ -43,12 +43,16 @@ def _list_json_following_pattern_by_domain(directory, glob_pattern):
     backups = {}
     for json_file in glob.glob(os.path.join(directory, glob_pattern)):
         logger.debug("{} detected".format(json_file))
-        with open(json_file, "r") as definition_file:
-            try:
-                metadata = json.load(definition_file)
-            except Exception as e:
-                logger.debug("Error for file {}: {}".format(json_file, e))
-                continue
+        try:
+            with open(json_file, "r") as definition_file:
+                try:
+                    metadata = json.load(definition_file)
+                except Exception as e:
+                    logger.debug("Error for file {}: {}".format(json_file, e))
+                    continue
+        except FileNotFoundError as e:
+            logger.warning(f"File vanished: {e}")
+            continue
         domain_name = metadata["domain_name"]
         if domain_name not in backups:
             backups[domain_name] = []

--- a/virt_backup/groups/complete.py
+++ b/virt_backup/groups/complete.py
@@ -51,7 +51,7 @@ def _list_json_following_pattern_by_domain(directory, glob_pattern):
                     logger.debug("Error for file {}: {}".format(json_file, e))
                     continue
         except FileNotFoundError as e:
-            logger.warning(f"File vanished: {e}")
+            logger.warning(f"File not found or already removed: {e}")
             continue
         domain_name = metadata["domain_name"]
         if domain_name not in backups:


### PR DESCRIPTION
When multiple clean group jobs start on several machines at the same time and they all use the same file system for storage, file names might exist in the global list that had vanished in the meantime and the 'open' call will raise a FileNotFoundError exception breaking the loop. Let's log a warning and continue processing.

<!--
    Thank you for your interest in contributing to virt-backup!

    Please note that this project uses black: https://black.readthedocs.io/en/stable/
    Install black via: https://black.readthedocs.io/en/stable/installation_and_usage.html#installation
    Then run from the root of this repository: black virt_backup tests

    WARNING: CI checks for black are enabled, Travis will then fail if there is any format issue.
-->
