### PR TITLE
Replace appdirs with platformdirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,11 @@ setup(
     keywords="libvirt",
     packages=find_packages(exclude=["example", "tests"]),
     install_requires=[
-        "appdirs",
         "arrow",
         "libvirt-python",
         "lxml",
         "packaging",
+        "platformdirs",
         "PyYAML",
     ],
     setup_requires=[

--- a/virt_backup/config.py
+++ b/virt_backup/config.py
@@ -1,7 +1,7 @@
 import errno
 import logging
 import os
-import appdirs
+import platformdirs
 import yaml
 
 from virt_backup import APP_NAME
@@ -11,8 +11,8 @@ logger = logging.getLogger("virt_backup")
 
 os.environ["XDG_CONFIG_DIRS"] = "/etc"
 CONFIG_DIRS = (
-    appdirs.user_config_dir(APP_NAME),
-    appdirs.site_config_dir(APP_NAME),
+    platformdirs.user_config_dir(APP_NAME),
+    platformdirs.site_config_dir(APP_NAME),
 )
 CONFIG_FILENAME = "config.yml"
 


### PR DESCRIPTION
Debian 13 no longer packages `appdirs` and recommends `platformdirs` instead: https://bugs-devel.debian.org/cgi-bin/bugreport.cgi?bug=1060427